### PR TITLE
Add # to Matrix link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -97,7 +97,7 @@ Call for Participation
 
 ## You have questions or want to contribute?
 
-Get in touch via [open-transport:matrix.org](https://matrix.to/#/#open-transport:matrix.org).
+Get in touch via [#open-transport:matrix.org](https://matrix.to/#/#open-transport:matrix.org).
 
 <small>Not familiar with Matrix? You can send us an email as well:<br/>
   <a href="mailto:info@open-transport.org">info@open-transport.org</a></small>


### PR DESCRIPTION
Update Matrix link, as suggested on the corresponding channel. Adding `#` should make the link easier to copy.