### PR TITLE
Add sold out information

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -62,10 +62,14 @@ schedule:
 
 The (un)conference about Free Software and Open Data for mobility and public transport.
 
+**SOLD OUT** Location limits have been reached. Registration is no longer possible.
+
 **Save the date: 17/18th of October in Vienna at [ÖBB's Innovation Factory!](https://openinnovation.oebb.at/de/spaces)**
 
 Connect with open source and open data communities from
 Transitous, MOTIS, OpenStreetMap, OpenTripPlanner, and many more!
+
+**SOLD OUT**
 
 ## Who are we?
 
@@ -99,6 +103,8 @@ Get in touch via [#open-transport:matrix.org](https://matrix.to/#/#open-transpor
   <a href="mailto:info@open-transport.org">info@open-transport.org</a></small>
 
 ## Location
+
+**SOLD OUT**
 
 <address>
 


### PR DESCRIPTION
Following the suggestions made in #24, this adds a brief note, that the event is sold out.

Not sure, if the repeated text is too much. But I assume, that people might not read everything, so added it, where people will probable see it.